### PR TITLE
Set opacity to 0 on input radio and checkbox

### DIFF
--- a/css/usajobs-design-system-base.css
+++ b/css/usajobs-design-system-base.css
@@ -1548,7 +1548,7 @@ legend {
 [type=checkbox],
 [type=radio] {
   position: absolute;
-  left: -999em;
+  opacity: 0;
 }
 
 .lt-ie9 [type=checkbox], .lt-ie9


### PR DESCRIPTION
Fixes the out-of-bounds focus outline showing up on Firefox. 

When testing within dev tools on a Windows machine it produced similar results ... _however_ ... I won't be able to fully test on Windows until this is merged and we can see this updated on the gh-pages branch.