### PR TITLE
CX JOA revisions

### DIFF
--- a/_data/job-announcements/gov-wide.json
+++ b/_data/job-announcements/gov-wide.json
@@ -67,8 +67,8 @@
   "QualificationSummary": "Subject matter experts will evaluate the first three pages of your resume and your design portfolio based on these competencies. You must show 52 weeks full time experience in all competencies listed below in order to qualify. Please make sure your resume reflects this time required.",
   "PositionRemuneration": [
     {
-      "MinimumRange": "76,687",
-      "MaximumRange": "138,572",
+      "MinimumRange": "99,172",
+      "MaximumRange": "166,500",
       "RateIntervalCode": "per year"
     }
   ],

--- a/_data/job-announcements/gov-wide.json
+++ b/_data/job-announcements/gov-wide.json
@@ -98,7 +98,7 @@
       "WhatToExpectNext": "",
       "RequiredDocuments": "",
       "Benefits": "",
-      "BenefitsURL": "https://www.usa.gov/benefits-for-federal-employees",
+      "BenefitsURL": "",
       "OtherInformation": "<p>Competitive applicants for GS 13 positions often have at least:</p><ul><li>5 years of experience</li><li>A bachelor's degree</li></ul>",
       "ConditionsOfEmployment": [
         "Successfully complete a background investigation.",

--- a/_includes/components/joa/usds/cx/how-you-will-be-evaluated.html
+++ b/_includes/components/joa/usds/cx/how-you-will-be-evaluated.html
@@ -2,7 +2,7 @@
   <h2 class="usajobs-joa-section__header--pilot">How you will be evaluated</h2>
   {% include components/joa/usds/cx/warning-evaluation.html %}
   <p>
-    The qualifications for this position will be evaluated by subject matter experts. Apply only if you meet the qualifications. If you are not selected for this position you may be considered for similar positions at High Impact Service Provider agencies for up to 1 year.
+    The qualifications for this position will be evaluated by subject matter experts. Apply only if you meet the qualifications.
   </p>
   <h4>Resume review</h4>
   <p>

--- a/_includes/components/joa/usds/cx/where-you-will-work.html
+++ b/_includes/components/joa/usds/cx/where-you-will-work.html
@@ -19,11 +19,13 @@
               Learn more about federal benefits
             </a>
           </li>
+          {% if job.UserArea.Details.BenefitsURL != '' %}
           <li>
             <a href="{{ job.UserArea.Details.BenefitsURL }}" target="_blank">
               Learn more about benefits at the {{ job.OrganizationName }}
             </a>
           </li>
+          {% endif %}
         </ul>
     </li>
     <li>

--- a/_site/job-announcement/v7.0/cx/index.html
+++ b/_site/job-announcement/v7.0/cx/index.html
@@ -329,8 +329,8 @@
         </span>
       </h5>
       <p class="usajobs-joa-summary__salary">
-        <span itemprop="baseSalary">$76,687</span> -
-        $138,572 per year
+        <span itemprop="baseSalary">$99,172</span> -
+        $166,500 per year
       </p>
     </li>
     <li class="usajobs-joa-summary__item usajobs-joa-summary--pilot__item">

--- a/_site/job-announcement/v7.0/cx/index.html
+++ b/_site/job-announcement/v7.0/cx/index.html
@@ -647,11 +647,7 @@
               Learn more about federal benefits
             </a>
           </li>
-          <li>
-            <a href="https://www.usa.gov/benefits-for-federal-employees" target="_blank">
-              Learn more about benefits at the Office of Personnel Management
-            </a>
-          </li>
+          
         </ul>
     </li>
     <li>
@@ -708,7 +704,7 @@
   </div>
 </div>
   <p>
-    The qualifications for this position will be evaluated by subject matter experts. Apply only if you meet the qualifications. If you are not selected for this position you may be considered for similar positions at High Impact Service Provider agencies for up to 1 year.
+    The qualifications for this position will be evaluated by subject matter experts. Apply only if you meet the qualifications.
   </p>
   <h4>Resume review</h4>
   <p>


### PR DESCRIPTION
Makes 3 changes:

1. Sets the salary to use DC locality pay.
2. Removes the 2nd Benefits URL if it is left blank and then makes it blank for this announcement.
3. Removes the redundant future consideration sentence from 1st paragraph in How you will be evaluated.